### PR TITLE
Remove soft-delete tag to modified/unchanged assets

### DIFF
--- a/__tests__/deploy.test.js
+++ b/__tests__/deploy.test.js
@@ -50,6 +50,8 @@ describe('deploy', () => {
     tagSet: {},
   }];
 
+  const unchanged = [];
+
   beforeAll(() => {
     mockLogger = new Logger();
     mockS3 = new S3();
@@ -59,7 +61,7 @@ describe('deploy', () => {
 
     expect.assertions(7);
 
-    return deploy(mockLogger, mockS3, added, modified, deleted, options).then((resolution) => {
+    return deploy(mockLogger, mockS3, added, modified, deleted, unchanged, options).then((resolution) => {
 
       expect(mockS3.lastUploadParams.Key).toEqual(modified[0].path.s3);
 
@@ -79,7 +81,7 @@ describe('deploy', () => {
 
     expect.assertions(1);
 
-    return deploy(mockLogger, mockS3, added, modified, deleted, { ...options, softDelete: true }).then(() => {
+    return deploy(mockLogger, mockS3, added, modified, deleted, unchanged, { ...options, softDelete: true }).then(() => {
 
       expect(mockS3.lastPutObjectTaggingParams.Key).toEqual(deleted[0].path.s3);
 

--- a/bin/deploy-aws-s3-cloudfront
+++ b/bin/deploy-aws-s3-cloudfront
@@ -30,8 +30,8 @@ Promise.resolve(((command, options) => {
 
     default:
       return changeset(logger, s3, options)
-        .then(({ added, deleted, modified }) => deployConfirmation(logger, added, modified, deleted, options))
-        .then(({ added, deleted, modified }) => deploy(logger, s3, added, modified, deleted, options))
+        .then(({ added, deleted, modified, unchanged }) => deployConfirmation(logger, added, modified, deleted, unchanged, options))
+        .then(({ added, deleted, modified, unchanged }) => deploy(logger, s3, added, modified, deleted, unchanged, options))
         .then(({ added, deleted, modified }) => (
           stale(modified, deleted, options)
             .then((stale) => invalidateConfirmation(logger, stale, options))

--- a/src/changeset.js
+++ b/src/changeset.js
@@ -142,6 +142,7 @@ module.exports = (logger, s3, options) => Promise.all([
     const added = [];
     const modified = [];
     const deleted = [];
+    const unchanged = [];
 
     localNames
       .concat(Object.keys(remoteNamesAndChecksums))
@@ -162,10 +163,12 @@ module.exports = (logger, s3, options) => Promise.all([
           }
         } else if (differ(logger, name, md5File.sync(options.source + name), remoteNamesAndChecksums[name])) {
           modified.push(info(name, false, options))
+        } else {
+          unchanged.push(info(name, false, options));
         }
 
       });
 
-    return { added, deleted, modified };
+    return { added, deleted, modified, unchanged };
 
   });

--- a/src/deployConfirmation.js
+++ b/src/deployConfirmation.js
@@ -1,6 +1,6 @@
 const { Confirm } = require('enquirer');
 
-module.exports = (logger, added, modified, deleted, options) => {
+module.exports = (logger, added, modified, deleted, unchanged, options) => {
 
   added.forEach((object) => {
     logger.info(`${object.path.relative} will be added`);
@@ -14,11 +14,15 @@ module.exports = (logger, added, modified, deleted, options) => {
     logger.warn(`${object.path.relative} will be ${options.softDelete ? 'soft-deleted' : 'deleted'}`);
   });
 
+  unchanged.forEach((object) => {
+    logger.warn(`${object.path.relative} will be kept unchanged`);
+  });
+
   return Promise.resolve(
     (!options.nonInteractive && (added.length || modified.length || deleted.length))
       ? new Confirm({ message: 'Proceed with deployment?' }).run()
       : true
   )
-    .then((confirmed) => confirmed ? { added, deleted, modified } : Promise.reject(new Error('Deployment was aborted by the user')));
+    .then((confirmed) => confirmed ? { added, deleted, modified, unchanged } : Promise.reject(new Error('Deployment was aborted by the user')));
 
 };


### PR DESCRIPTION
Scenario (with soft-deletion active):

* Deploy 1: `foo.css` gets added to the bucket
* Deploy 2: `foo.css` gets soft-deleted from the bucket
* Deploy 3: `foo.css` get added back again to the bucket

Issue: `foo.css` is still tagged to be soft-deleted. This PR fixes this by removing the soft-delete tag to every modified/unchanged file in the remote bucket.